### PR TITLE
Updates procfile jar

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar build/libs/taskrunner_taskui.jar
+web: java -jar build/libs/build_*.jar


### PR DESCRIPTION
Updates jar
sshing into heroku showed that jars have names like: build_d997ab93.jar
not sure why it is not using the project name like my local env is